### PR TITLE
Added Section on UTF-8 Encoding in PowerShell

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ make an algorithm that quantifies randomness in a password
 try bst
 
 try a text file with a lot of words
+
+# Unicode Rendering [POWERSHELL]
+
+```powershell
+$OutputEncoding = [console]::InputEncoding = [console]::OutputEncoding =
+                    New-Object System.Text.UTF8Encoding
+```
+Set text encoding to UTF-8. [Source](https://stackoverflow.com/questions/40098771/changing-powershells-default-output-encoding-to-utf-8)

--- a/main.c
+++ b/main.c
@@ -74,7 +74,7 @@ int main(void) {
         c[i] = getch();
         if (isalnum(c[i]) || ispunct(c[i])) {
             size++;
-            printf("*");
+            printf("\u2022");
         }
         if (!isprint(c[i]) && c[i] != '\b') {
             printf("\nbreak\n");
@@ -84,7 +84,7 @@ int main(void) {
             backspace++;
             printf("\r               \r");
             for (int i = 0; i < size - backspace - 2; i++) {
-                printf("*");
+                printf("\u2022");
             }
             i-=2;
         }


### PR DESCRIPTION
Bullet point printing works. The default encoding setting isn't set to UTF-8, therefore the bullet point would not render correctly. To fix this, the user can run the command given in the README.md file to alternatively use the command,

```powershell
$PSDefaultParameterValues['Out-File:Encoding'] = 'utf8'
```

as found [here](https://stackoverflow.com/questions/40098771/changing-powershells-default-output-encoding-to-utf-8).